### PR TITLE
vp9hdec: fix pCurrFrame->pMdfSurface NULL pointer issue

### DIFF
--- a/src/vp9hdec/decode_hybrid_vp9.cpp
+++ b/src/vp9hdec/decode_hybrid_vp9.cpp
@@ -3289,9 +3289,16 @@ VAStatus Intel_HybridVp9Decode_HostVldRenderCb (
 
     // Reset padding flag of current frame and update surface dimension
     surface = SURFACE(pMdfDecodeFrame->ucCurrIndex);
+    if ((surface == NULL) || (surface->private_data == NULL))
+        return VA_STATUS_ERROR_INVALID_PARAMETER;
+
     pFrameSource = (INTEL_DECODE_HYBRID_VP9_MDF_FRAME_SOURCE *)(surface->private_data);
     pCurrFrame = &(pFrameSource->Frame);
     pFrameSource->bHasPadding = false;
+
+    if (pCurrFrame->pMdfSurface == NULL)
+        return VA_STATUS_ERROR_INVALID_PARAMETER;
+
     pCurrFrame->pMdfSurface->SetSurfaceStateDimensions(
         pMdfDecodeFrame->dwWidth,
         pMdfDecodeFrame->dwHeight);


### PR DESCRIPTION
There is "Segmentation fault" error when run vp9 decode test on BSW/BDW Chromebook by following tool command line: /usr/local/libexec/chrome-binary-tests/decode_test --md5 --visible --video=vp9_video.ivf

Add null point detection function in Intel_HybridVp9Decode_HostVldRenderCb to aviod this issue.

Signed-off-by: Cooper Chiou <cooper.chiou@intel.com>